### PR TITLE
Fix ReactDOM import in index.js

### DIFF
--- a/flashcards-marketing-app/src/index.js
+++ b/flashcards-marketing-app/src/index.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom/client';
+import { createRoot } from 'react-dom/client';
 import App from './App';
 import './styles/App.css';
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
+const rootElement = document.getElementById('root');
+const root = createRoot(rootElement);
 root.render(<App />);


### PR DESCRIPTION
## Summary
- use `createRoot` named export instead of default `ReactDOM` import
- add missing newline at end of file

## Testing
- `node node_modules/react-scripts/bin/react-scripts.js test --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6843b37ac70c83318c5f2ca70fb22bb8